### PR TITLE
TiVo Series 3 support:

### DIFF
--- a/lib/tivohmo/server.rb
+++ b/lib/tivohmo/server.rb
@@ -318,7 +318,9 @@ module TivoHMO
           builder :server_info, layout: true
 
         when 'QueryItem' then
-          builder(layout: true) {|xml| xml.QueryItem }
+	  # pyTivo returns 404 when we try this (and doesn't crash the TiVo)
+          # builder(layout: true) {|xml| xml.QueryItem }
+	  unsupported
 
         when 'FlushServer' then
           builder(layout: true) {|xml| xml.FlushServer }

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -162,7 +162,8 @@ describe TivoHMO::Server do
 
     it "should have a stub response for QueryItem" do
       get '/TiVoConnect?Command=QueryItem'
-      expect(last_response.status).to eq(200)
+      # but make this 404 (like pyTivo) instead of 200
+      expect(last_response.status).to eq(404)
     end
 
     it "should have a response for QueryServer" do


### PR DESCRIPTION
Browsing more or less works, but transfers to a TiVo Series 3 (or TiVo HD)
caused the TiVo to crash. Examination of transfers of the same file using
tivohmo and pyTivo showed this difference:

Query (from TiVo):
    GET /TivoConnect?Command=QueryItem&Url=...

pyTivo:
    HTTP/1.1 404 Not Found

tivohmo:
    HTTP/1.1 200 OK
    [...headers omitted for brevity...]
    <?xml
      version="1.0"
      encoding="UTF-8"
      ?>
    <QueryItem/>

It is unclear to me if my TiVos hate all QueryItem responses, or just null
responses (like above). Since there is nothing being returned anyway, this
commit removes support for QueryItem.

The result is that tivohmo matches pyTivo behavior now and my transfers
are successful.
